### PR TITLE
Develop

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ ARG AIRFLOW_DATA_PATH=/usr/local/airflow_data
 ARG AIRFLOW_EXTRA_DEPS=""
 ARG SYSTEM_EXTRA_DEPS=""
 
-RUN set -ex \
-    && apt-get update -yqq \
+RUN apt-get update -yqq \
     && apt-get upgrade -yqq \
     && apt-get install -yqq --no-install-recommends \
         build-essential \
@@ -37,29 +36,26 @@ RUN set -ex \
         libffi-dev \
         libkrb5-dev \
         ${SYSTEM_EXTRA_DEPS} \
-    && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && useradd --shell /bin/bash --create-home --home ${AIRFLOW_HOME} airflow \
     && pip install -U pip setuptools wheel \
-    && pip install ndg-httpsclient pytz pyOpenSSL pyasn1 ipython psycopg2-binary \
+    && pip install ndg-httpsclient pytz pyOpenSSL pyasn1 typing-extensions ipython psycopg2-binary \
     && pip install apache-airflow[async,aws,crypto,mysql,postgres,password,ssh${AIRFLOW_EXTRA_DEPS:+,}${AIRFLOW_EXTRA_DEPS}]==${AIRFLOW_VERSION} \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \
     && rm -rf \
         /var/lib/apt/lists/* \
         /var/tmp/* \
-        /tmp/* \
+        /tmp/*
 
 COPY entrypoint.sh ${AIRFLOW_HOME}/entrypoint.sh
 COPY airflow.cfg ${AIRFLOW_HOME}/airflow.cfg
-COPY requirements.txt ${AIRFLOW_HOME}/requirements.txt
 
-RUN FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print FERNET_KEY") \
-    && sed -i "s/#FERNET_KEY#/${FERNET_KEY}/" ${AIRFLOW_HOME}/airflow.cfg
-RUN sed -i "s:#AIRFLOW_HOME#:${AIRFLOW_HOME}:" ${AIRFLOW_HOME}/airflow.cfg
+RUN FERNET_KEY=$(python -c "from cryptography.fernet import Fernet; FERNET_KEY = Fernet.generate_key().decode(); print(FERNET_KEY)") \
+    && sed -i "s|{FERNET_KEY}|${FERNET_KEY}|g" ${AIRFLOW_HOME}/airflow.cfg \
+    && sed -i "s|{AIRFLOW_HOME}|${AIRFLOW_HOME}|g" ${AIRFLOW_HOME}/airflow.cfg
 RUN mkdir -p ${AIRFLOW_HOME}/logs && mkdir -p ${AIRFLOW_HOME}/dags && mkdir -p ${AIRFLOW_DATA_PATH}
 RUN chown -R airflow: ${AIRFLOW_HOME} && chown -R airflow: ${AIRFLOW_DATA_PATH}
 RUN chmod +x ${AIRFLOW_HOME}/entrypoint.sh
-RUN pip install --no-cache-dir -r ${AIRFLOW_HOME}/requirements.txt
 
 WORKDIR ${AIRFLOW_HOME}
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help ps build up down restart shell shell-root shell-ipython shell-db clean-cache
+SHELL=/bin/bash
+
+help:
+	@echo 'make ps               list containers.'
+	@echo 'make build            build an image from a Dockerfile.'
+	@echo 'make up               build, (re)create, start, and attach to containers for a service.'
+	@echo 'make down             stop and remove containers, networks, volumes, and images created by up.'
+	@echo 'make restart          restart all stopped and running services.'
+	@echo 'make shell            connect to webserver container in new bash shell.'
+	@echo 'make shell-root       connect to webserver container in new bash shell as root.'
+	@echo 'make shell-ipython    connect to webserver container in new bash shell.'
+	@echo 'make shell-db         shell into psql inside postgres container.'
+	@echo 'make clean-cache 	 remove python cache files from tree.'
+
+
+ps: docker-ps
+build:docker-build
+up: docker-up
+down: docker-down
+restart: docker-down docker-up
+
+docker-ps:
+	docker-compose ps
+
+docker-build:
+	docker-compose build
+
+docker-up:
+	docker-compose up -d --build
+
+docker-down:
+	docker-compose down
+
+shell:
+	docker-compose exec -u airflow webserver bash
+
+shell-root:
+	docker-compose exec -u root webserver bash
+
+shell-ipython:
+	docker-compose exec -u airflow webserver ipython
+
+shell-db:
+	docker-compose exec postgres psql -w --username "airflow" --dbname "airflow"
+
+clean-cache:
+	find . -name '*.py[cod]' -exec rm --force {} +

--- a/README.md
+++ b/README.md
@@ -6,10 +6,21 @@
 - Install [Docker Compose](https://docs.docker.com/compose/install/)
 - Follow Apache Airflow Principles and How-To Guides in [Docs](https://airflow.apache.org/docs/stable/)
 
+### Usage
+
+For the first run, build containers using predefined **make** shortcuts:
+```bash
+make up
+```
+to list all available make shortcuts, type
+```bash
+make help
+```
+
 ### Create Superuser
 
 ```bash
-docker-compose run --rm webserver bash
+docker-compose run --rm webserver bash  # or make shell-root
 airflow create_user [-h] [-r ROLE] [-u USERNAME] [-e EMAIL] [-f FIRSTNAME] \
                     [-l LASTNAME] [-p PASSWORD] [--use_random_password]
 ```
@@ -23,7 +34,6 @@ If you want to run any of airflow commands, you can do the following:  `docker-c
 - `docker-compose run --rm webserver python /usr/local/airflow/dags/[PYTHON-FILE].py` - Test custom python script
 
 ## TODO
-- Makefile
 - Solve Fernet Key Issue
 - Celery Executor
 - User-defined backend support

--- a/README.md
+++ b/README.md
@@ -6,9 +6,24 @@
 - Install [Docker Compose](https://docs.docker.com/compose/install/)
 - Follow Apache Airflow Principles and How-To Guides in [Docs](https://airflow.apache.org/docs/stable/)
 
+### Create Superuser
+
+```bash
+docker-compose run --rm webserver bash
+airflow create_user [-h] [-r ROLE] [-u USERNAME] [-e EMAIL] [-f FIRSTNAME] \
+                    [-l LASTNAME] [-p PASSWORD] [--use_random_password]
+```
+
+## Executing airflow commands
+
+If you want to run any of airflow commands, you can do the following:  `docker-compose run --rm webserver [some command]`
+
+- `docker-compose run --rm webserver airflow list_dags` - List dags
+- `docker-compose run --rm webserver airflow test [DAG_ID] [TASK_ID] [EXECUTION_DATE]` - Test specific task
+- `docker-compose run --rm webserver python /usr/local/airflow/dags/[PYTHON-FILE].py` - Test custom python script
+
 ## TODO
-- Docker-compose file
 - Makefile
-- Security improvements
+- Solve Fernet Key Issue
 - Celery Executor
 - User-defined backend support

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -101,7 +101,7 @@ load_examples = False
 plugins_folder = {AIRFLOW_HOME}/plugins
 
 # Secret key to save connection passwords in the db
-fernet_key =
+fernet_key = {FERNET_KEY}
 
 # Whether to disable pickling dags
 donot_pickle = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.5'
+
+services:
+  postgres:
+    image: postgres:12.3-alpine
+    environment:
+      POSTGRES_DB: airflow
+      POSTGRES_USER: airflow
+      POSTGRES_PASSWORD: airflow
+    ports:
+      - 5432:5432
+    volumes:
+      - ./data/postgres:/var/lib/postgresql/data
+
+  webserver:
+    build:
+      context: .
+    restart: always
+    depends_on:
+      - postgres
+    volumes:
+      - ./airflow/dags:/usr/local/airflow/dags
+      - ./airflow/logs:/usr/local/airflow/logs
+      - ./data/webserver:/usr/local/airflow_data
+    ports:
+      - 8080:8080
+    command: webserver
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f /usr/local/airflow/airflow-webserver.pid ]"]
+      interval: 30s
+      timeout: 30s
+      retries: 3

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+if [[ -e "./requirements.txt" ]]; then
+    $(command -v pip) install -r ./requirements.txt
+fi
+
+case "$1" in
+  webserver)
+    airflow initdb
+    airflow scheduler &
+    exec airflow webserver
+    ;;
+  scheduler|worker)
+    sleep 20
+    exec airflow "$@"
+    ;;
+  *)
+    exec "$@"
+    ;;
+esac


### PR DESCRIPTION
- add the entrypoint for **airflow webserver**
- compose with **docke-compose.yml**
- add **Makefile**
- implement hard-coded fernet-key generation during build
- install missing 'typing-extensions' package as a workaround for [AIRFLOW-685](https://issues.apache.org/jira/browse/AIRFLOW-685)