### PR TITLE
Tech/airflow 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GUNICORN_CMD_ARGS --log-level WARNING
 ARG AIRFLOW_HOME=/usr/local/airflow
 ENV AIRFLOW_HOME=${AIRFLOW_HOME}
 
-ARG AIRFLOW_VERSION=1.10.13
+ARG AIRFLOW_VERSION=1.10.14
 ARG AIRFLOW_DATA_PATH=/usr/local/airflow_data
 ARG AIRFLOW_EXTRA_DEPS=""
 ARG SYSTEM_EXTRA_DEPS=""
@@ -38,7 +38,7 @@ RUN apt-get update -yqq \
         ${SYSTEM_EXTRA_DEPS} \
     && useradd --shell /bin/bash --create-home --home ${AIRFLOW_HOME} airflow \
     && pip install -U pip setuptools wheel \
-    && pip install ndg-httpsclient pytz pyOpenSSL pyasn1 typing-extensions ipython psycopg2-binary cattrs==1.0.0 \
+    && pip install ndg-httpsclient pytz pyOpenSSL pyasn1 typing-extensions ipython psycopg2-binary \
     && pip install apache-airflow[async,aws,crypto,mysql,postgres,password,ssh${AIRFLOW_EXTRA_DEPS:+,}${AIRFLOW_EXTRA_DEPS}]==${AIRFLOW_VERSION} \
     && apt-get autoremove -yqq --purge \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -14,9 +14,15 @@ In order to secure Airflow Connections and Variables, generate `fernet_key`. It 
 >> Fernet.generate_key().decode()
 '=69ksvvORDpeoBrz2N38El18kOxJFPU2peg22So66k7U=' # here is your fernet key
 ```
-Store the generated key in **env_file** called `airflow.env` like It shown below:
+Specify the `secret_key` setting under the `[webserver]` config. 
+Change this value to a new, per-environment, randomly generated string.
+
+For example using this command `openssl rand -hex 30`
+
+Store the generated keys in **env_file** and name It `airflow.env`, just like It shown below:
 ```bash
 AIRFLOW__CORE__FERNET_KEY=69ksvvORDpeoBrz2N38El18kOxJFPU2peg22So66k7U=
+AIRFLOW__WEBSERVER__SECRET_KEY=1ca384d704f852756df25a7560c3338cb3a65cccf2fd734440f94deb5d32
 ```
 **Note:** You can use `airflow.env` to define any container-level [configurations](https://airflow.readthedocs.io/en/stable/howto/set-config.html) for Airflow. 
 
@@ -33,12 +39,16 @@ to list all available make shortcuts, type
 make help
 ```
 
-### Create Superuser
+### Create Users
 
 ```bash
 docker-compose run --rm webserver bash  # or make shell-root
-airflow create_user [-h] [-r ROLE] [-u USERNAME] [-e EMAIL] [-f FIRSTNAME] \
-                    [-l LASTNAME] [-p PASSWORD] [--use_random_password]
+airflow users create \
+    --role Admin \
+    --username admin \
+    --firstname FIRST_NAME \
+    --lastname LAST_NAME \
+    --email EMAIL@example.org
 ```
 
 ## Executing airflow commands

--- a/airflow.cfg
+++ b/airflow.cfg
@@ -1,7 +1,4 @@
 [core]
-# The home folder for airflow, default is ~/airflow
-
-airflow_home = {AIRFLOW_HOME}
 
 # The folder where your airflow pipelines live, most likely a
 # subfolder in a code repository
@@ -110,7 +107,7 @@ donot_pickle = False
 dagbag_import_timeout = 30
 
 # The class to use for running task instances in a subprocess
-task_runner = BashTaskRunner
+task_runner = StandardTaskRunner
 
 # If set, tasks without a `run_as_user` argument will be run with this user
 # Can be used to de-elevate a sudo user running Airflow when executing tasks
@@ -442,7 +439,7 @@ statsd_prefix = airflow
 
 # The scheduler can run multiple threads in parallel to schedule dags.
 # This defines how many threads will run.
-max_threads = 2
+parsing_processes = 2
 
 authenticate = False
 

--- a/airflow/dags/.airflowignore
+++ b/airflow/dags/.airflowignore
@@ -1,1 +1,1 @@
-/dag_utils
+/utils

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
       POSTGRES_DB: airflow
       POSTGRES_USER: airflow
       POSTGRES_PASSWORD: airflow
-    ports:
-      - 5432:5432
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,7 +6,8 @@ fi
 
 case "$1" in
   webserver)
-    airflow initdb
+    airflow db init
+#    airflow db upgrade
     airflow scheduler &
     exec airflow webserver
     ;;


### PR DESCRIPTION
From [Airflow Docs](https://airflow.apache.org/docs/apache-airflow/stable/upgrading-to-2.html):

> As mentioned earlier in Step 2, the 1.10.14 release is intended to be a "bridge release" which would be a step in the migration to Airflow 2.0.

Prepare project files and airflow config for the new Airflow 2.0 release:

- bump airflow to 1.10.14, health-check performed
- update configs
- update Dockerfile and Readme